### PR TITLE
concept: limit regios where plants re-grow

### DIFF
--- a/VS/TT-RespawnablePlants/TT-RespawnablePlants.csproj
+++ b/VS/TT-RespawnablePlants/TT-RespawnablePlants.csproj
@@ -45,6 +45,8 @@
     </ItemDefinitionGroup>
     <ItemGroup>
       <PackageReference Include="STBlade.Modding.TLD.Il2CppAssemblies.Windows" Version="2.35.0" />
+      <PackageReference Include="stblade.Modding.TLD.ModData" Version="1.5.1"/>
+      <PackageReference Include="STBlade.Modding.TLD.ModSettings" Version="1.9.0" />
     </ItemGroup>
 
     <!--This is the list of assemblies that the mod references. Most of these are unnecessary for normal mods, but are included here for completeness.-->

--- a/VS/TT-RespawnablePlants/src/Settings.cs
+++ b/VS/TT-RespawnablePlants/src/Settings.cs
@@ -32,6 +32,13 @@ namespace TinyTweaks
         })]
         public int randomizeRespawnTime;
 
+        [Name("Respawn regions")]
+        [Description("Limit respawn to certian regions.\n Enabling regions mid-game will not respawn already harvested plants.")]
+        [Choice(new string[] {
+          "All",
+          "Limited"
+        })]
+        public int limitRegions;
 
         protected override void OnConfirm()
         {

--- a/VS/TT-RespawnablePlants/src/UnbreakablePatches.cs
+++ b/VS/TT-RespawnablePlants/src/UnbreakablePatches.cs
@@ -85,16 +85,27 @@ namespace TinyTweaks
         {
             internal static void Postfix(ref Harvestable __instance)
             {
+              bool respawnAllowed = false;
                 if (__instance.m_Harvested && __instance.RegisterAsPlantsHaversted)
                 {
                     string scene = GameManager.m_ActiveScene;
-                    if (!harvestedPlants.ContainsKey(scene))
+                    if (Settings.options.limitRegions == 0 )
                     {
-                        harvestedPlants.Add(scene, new Dictionary<string, float>());
+                      respawnAllowed = true;
                     }
+                    else if (Settings.options.limitRegions == 1 && (scene == "AshCanyonRegion" || scene == "RiverValleyRegion" || scene == "MiningRegion"))
+                    {
+                      respawnAllowed = true;
+                    }
+                    if (respawnAllowed) {
+                      if (!harvestedPlants.ContainsKey(scene))
+                      {
+                          harvestedPlants.Add(scene, new Dictionary<string, float>());
+                      }
 
-                    string guid = ObjectGuid.GetGuidFromGameObject(__instance.gameObject);
-                    harvestedPlants[scene][guid] = GameManager.GetTimeOfDayComponent().GetHoursPlayedNotPaused();
+                      string guid = ObjectGuid.GetGuidFromGameObject(__instance.gameObject);
+                      harvestedPlants[scene][guid] = GameManager.GetTimeOfDayComponent().GetHoursPlayedNotPaused();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Hey,
Normally i do not want plants to re-grow but after some time:
1) i do start miss resources (garden mod was good filler for this)
2) I do not have reason to visit some regions, specially ones that are remote like AC or HRV.

This way I can actually put tick box on both. This will enable re-grow only on some scenes (AC, HRV and ZOC).
I've pick them as 2 first are remote ones, while ZOC it's different kind of difficult.

Implementation is meh - perhaps listing each region in settings with true/false will be more user-friendly.

LMK (here/discord) what You think about this idea?