### PR TITLE
Fix Breaking down speed slider having no effect

### DIFF
--- a/VS/TT-SpeedyInteractions/src/UnbreakablePatches.cs
+++ b/VS/TT-SpeedyInteractions/src/UnbreakablePatches.cs
@@ -181,11 +181,10 @@ namespace TinyTweaks
         {
             internal static void Prefix(Panel_BreakDown __instance)
             {
-                if (Settings.options.globalSpeedMult != 1f)
-                {
-                    __instance.m_SecondsToBreakDown = genericSliderTime / Settings.options.breakdownSpeedMult;
-
-                }
+                // Not gated on != 1f: the panel keeps using this value while the action runs,
+                // so it cannot be restored in a postfix. Writing it every time means 1x puts
+                // the stock value back instead of leaving the panel stuck at the last speed.
+                __instance.m_SecondsToBreakDown = genericSliderTime / Settings.options.breakdownSpeedMult;
             }
         }
 


### PR DESCRIPTION
Two defects in the `Panel_BreakDown.OnBreakDown` patch (`GlobalSpeed2`) in TT-SpeedyInteractions.

**1. Wrong multiplier in the gate.** The condition tests `globalSpeedMult` but the division uses `breakdownSpeedMult`, so the Breaking down slider does nothing unless Actions is also off 1x. Every other speed patch in the file gates on its own multiplier.

**2. The value goes stale.** Because the write is skipped at 1x, nothing puts the stock value back, so lowering the setting mid-session has no effect until a restart.

I first tried the stash-in-prefix / restore-in-postfix pattern used by `EatingSpeed` and `RefuelSpeed`, but it does not work here. `Panel_BreakDown` keeps reading `m_SecondsToBreakDown` while the action runs rather than consuming it at start, so restoring in a postfix cancels the speedup entirely (measured: both patches fired, and the bar still ran at the restored duration). Dropping the gate and writing unconditionally fixes both issues; at 1x it writes `genericSliderTime / 1`, the stock 3.0.

Measured on TLD 2.55, changing settings through the ModSettings menu:

| Actions | Breaking down | before | after |
|---|---|---|---|
| 1x | 3x | no change, prefix never ran | ~1s |
| 1x | 1x, after a 3x run | stuck fast until restart | ~3s, stock |

Also confirmed the game never assigns `m_SecondsToBreakDown` per object: a value pinned on the panel survived breaking down both a plank and a cardboard box untouched, and each took the pinned duration. The per-object cost lives in `m_DurationHours`, which this patch does not touch, so a flat `genericSliderTime / mult` is equivalent to scaling here.
