### PR TITLE
Fix speed sliders not applying when lowered back to 1x

### DIFF
--- a/VS/TT-SpeedyInteractions/src/Settings.cs
+++ b/VS/TT-SpeedyInteractions/src/Settings.cs
@@ -66,6 +66,7 @@ namespace TinyTweaks
         protected override void OnConfirm()
         {
             base.OnConfirm();
+            SpeedyInteractions.ApplySpeedsToLoadedPanels();
         }
     }
 

--- a/VS/TT-SpeedyInteractions/src/UnbreakablePatches.cs
+++ b/VS/TT-SpeedyInteractions/src/UnbreakablePatches.cs
@@ -18,6 +18,42 @@ namespace TinyTweaks
         }
 
 
+        internal static void ApplySpeedsToLoadedPanels()
+        {
+            float g = Settings.options.globalSpeedMult;
+
+            foreach (var p in Resources.FindObjectsOfTypeAll<Panel_BreakDown>())
+                p.m_SecondsToBreakDown = genericSliderTime / Settings.options.breakdownSpeedMult;
+
+            foreach (var p in Resources.FindObjectsOfTypeAll<Panel_Crafting>())
+                p.m_CraftingDisplayTimeSeconds = craftingSliderTime / g;
+
+            foreach (var p in Resources.FindObjectsOfTypeAll<Panel_Cooking>())
+                p.m_RecipePreparationDisplayTimeSeconds = craftingSliderTime / g;
+
+            foreach (var p in Resources.FindObjectsOfTypeAll<Panel_Milling>())
+                p.m_RepairRealTimeSeconds = craftingSliderTime / g;
+
+            foreach (var p in Resources.FindObjectsOfTypeAll<Panel_SnowShelterBuild>())
+                p.m_RealtimeSecondsToBuild = genericSliderTime / g;
+
+            foreach (var p in Resources.FindObjectsOfTypeAll<Panel_SnowShelterInteract>())
+                p.m_RealtimeSecondsToRepairOrDismantle = genericSliderTime / g;
+
+            foreach (var p in Resources.FindObjectsOfTypeAll<Panel_PickWater>())
+                p.m_ProgressBarDurationSecondsBase = shortSliderTime / g;
+
+            foreach (var p in Resources.FindObjectsOfTypeAll<Panel_IceFishingHoleClear>())
+                p.m_ProgressBarSeconds = longSliderTime / g;
+
+            foreach (var rc in Resources.FindObjectsOfTypeAll<RockCache>())
+            {
+                rc.m_BuildRealSecondsElapsed = Mathf.CeilToInt(shortSliderTime / g);
+                rc.m_DismantleRealSecondsElapsed = Mathf.CeilToInt(shortSliderTime / g);
+            }
+        }
+
+
         [HarmonyPatch(typeof(PlayerManager), nameof(PlayerManager.UseFoodInventoryItem))]
         private static class EatingSpeed
         {
@@ -181,7 +217,7 @@ namespace TinyTweaks
         {
             internal static void Prefix(Panel_BreakDown __instance)
             {
-                if (Settings.options.globalSpeedMult != 1f)
+                if (Settings.options.breakdownSpeedMult != 1f)
                 {
                     __instance.m_SecondsToBreakDown = genericSliderTime / Settings.options.breakdownSpeedMult;
 


### PR DESCRIPTION
Two defects in TT-SpeedyInteractions, both about a slider not applying.

**1. Wrong multiplier.** `GlobalSpeed2` tests `globalSpeedMult` but divides by `breakdownSpeedMult`, so the Breaking down slider does nothing unless Actions is also off 1x. Now tests `breakdownSpeedMult`.

**2. Panels stay stuck at the last speed.** The panel patches skip their write at 1x, and the game never reassigns those fields, so lowering a slider back to 1x has no effect until a restart. `TTSettings.OnConfirm` now pushes the current values onto the loaded panels. The guards are unchanged.

Measured on TLD 2.55. At Actions 3x, confirming sets crafting to 1.667 with no action performed. Back at 1x it returns to the stock 5, where before it stayed at 1.667. Breaking down 3x with Actions 1x now gives 1.0 without touching the other panels.

Writing the stock value back is only safe because each hardcoded constant matches what the game authors on the panel. I checked all four live: 3, 5, 2, 10.

Left alone after checking: the eating and refuel patches (stash and restore, verified working in game), `ExamineActionSpeed` and `HoldInteractionTime` (the game refills those fields per use), and `AfflictionTreatmentSpeed1/2` (return value only).

Not fixed here: the `RockCache` fields are `Int32`, so `CeilToInt(2/mult)` is 1 from 2x upward and the slider has no further effect past 2x. Nothing to do about that while the field is an int, and `FloorToInt` would write 0.

Supersedes #8.
